### PR TITLE
Switch to @google/genai for Gemini models

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ const geminiService = {
   apiKey: 'your-gemini-api-key',
 };
 
+// Gemini messages use roles 'user' and 'model' as defined by the
+// `@google/genai` library.
+
 // Define model configurations
 const models = {
   gpt4: {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.29.2",
-    "@google/generative-ai": "^0.3.1",
+    "@google/genai": "^1.3.0",
     "ollama": "^0.5.9",
     "openai": "^4.67.3",
     "ora": "^8.1.0"

--- a/src/adapters/BaseAdapter.ts
+++ b/src/adapters/BaseAdapter.ts
@@ -1,8 +1,9 @@
-import { Content } from '@google/generative-ai';
+import { Content } from '@google/genai';
 
 export type RoleOpenAI = 'user' | 'assistant' | 'system';
 export type RoleAnthropic = 'user' | 'assistant';
 export type RoleOllama = 'user' | 'assistant' | 'system';
+export type RoleGemini = 'user' | 'model';
 
 export interface AdapterResponse<T = string> {
   data: T;
@@ -36,4 +37,6 @@ export interface OllamaChatCompletionMessage {
   role: RoleOllama;
 }
 
-export type GeminiChatCompletionMessage = Content;
+export interface GeminiChatCompletionMessage extends Content {
+  role?: RoleGemini;
+}

--- a/src/adapters/GeminiAdapter.ts
+++ b/src/adapters/GeminiAdapter.ts
@@ -1,4 +1,4 @@
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { GoogleGenAI } from '@google/genai';
 
 import {
   BaseAdapter,
@@ -25,19 +25,19 @@ export class GeminiAdapter implements BaseAdapter<string> {
       );
     }
 
-    const genAi = new GoogleGenerativeAI(serviceConfig.apiKey);
+    const genAi = new GoogleGenAI({ apiKey: serviceConfig.apiKey });
 
     try {
-      const model = genAi.getGenerativeModel({ model: modelName });
-      const result = await model.generateContent({
+      const result = await genAi.models.generateContent({
+        model: modelName,
         contents: messages,
-        generationConfig: {
+        config: {
           maxOutputTokens: modelConfig.max_tokens ?? 300,
         },
       });
 
       return {
-        data: result.response.text() || '',
+        data: result.text || '',
         metadata: {
           modelUsed: modelConfig.name,
           timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- migrate Gemini support to `@google/genai`
- document roles for Gemini messages in README

## Testing
- `npm run build`
- `npm run lint`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68404eeeaf0083278a289068a25bfd45