### PR TITLE
Add web preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ processInput('What is the weather like in New York?');
 The current weather in New York is sunny with a temperature of 25°C.
 ```
 
+### Web Preview
+
+You can inspect your MultiLlama configuration in the browser by running:
+
+```bash
+npx multillama web
+```
+
+This starts a local server at [http://localhost:3300](http://localhost:3300) that renders the loaded configuration.
+
 ---
 
 *Happy Coding!* 🦙🎉

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "OpenAI",
     "LLM",
     "Natural Language Processing"
-  ]
+  ],
+  "bin": {
+    "multillama": "dist/cli.js"
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import http from 'http';
+import ConfigManager from './config/ConfigManager.js';
+
+const args = process.argv.slice(2);
+
+function startWeb(port: number) {
+  let config;
+  try {
+    config = ConfigManager.getConfig();
+  } catch (err) {
+    try {
+      ConfigManager.initializeFromFile('multillama.config.json');
+      config = ConfigManager.getConfig();
+    } catch (err2) {
+      console.error('MultiLlama configuration not found.');
+      process.exit(1);
+    }
+  }
+  const html = `<html><head><title>MultiLlama Connections</title></head><body><h1>MultiLlama Connections</h1><pre>${JSON.stringify(config, null, 2)}</pre></body></html>`;
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(html);
+  });
+  server.listen(port, () => {
+    console.log(`Server running at http://localhost:${port}`);
+  });
+}
+
+if (args[0] === 'web') {
+  const port = 3300;
+  startWeb(port);
+} else {
+  console.log('Usage: multillama web');
+}


### PR DESCRIPTION
## Summary
- add a CLI entry point with a `web` command
- expose new binary `multillama`
- document the web preview usage

## Testing
- `npm run build`
- `npm test -- -passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6846645b6cdc832796c70df2153bcce5